### PR TITLE
use Catalyst::Test rather than Test::WWW::Mechanize::Catalyst

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -1,124 +1,102 @@
-#! perl
-
 use strict;
 use warnings;
 use Test::More;
 
-use lib qw(lib t/lib);
+use lib qw(t/lib);
 
-BEGIN {
-    $ENV{CATALYST_DEBUG} = 0;
-}
-
-use Test::WWW::Mechanize 1.46;    # For the header_xxx tests
-use Test::WWW::Mechanize::Catalyst;
+use Catalyst::Test qw( Test::App );
 
 my $no_cache
     = 'no-cache, no-store, must-revalidate, max-age=0, max-stale=0, post-check=0, pre-check=0, private';
 
-my $mech = Test::WWW::Mechanize::Catalyst->new( catalyst_app => 'Test::App' );
+subtest 'no special headers' => sub {
+    my $res = request('/');
+    like $res->content, qr/index page/;
 
-{
-    note('Testing no special headers');
+    is $res->header('Surrogate-Control'), undef,
+        'No Surrogate-Control header';
+    is $res->header('Cache-Control'), undef,
+        'No Cache-Control header';
+    is $res->header('Pragma'), undef,
+        'No Pragma header';
+    is $res->header('Expires'), undef,
+        'No Expires header';
+};
 
-    $mech->get('/');
-    $mech->content_contains("index page");
+subtest 'XXX_never_cache headers' => sub {
+    my $res = request('/page_with_no_caching');
+    like $res->content, qr/No caching here/;
 
-    $mech->lacks_header_ok( 'Surrogate-Control',
-        'No Surrogate-Control header' );
-    $mech->lacks_header_ok( 'Cache-Control', 'No Cache-Control header' );
-    $mech->lacks_header_ok( 'Pragma',        'No Pragma header' );
-    $mech->lacks_header_ok( 'Expires',       'No Expires header' );
-}
+    is $res->header('Surrogate-Control'), undef,
+        'Surrogate-Control not there as expected';
+    is $res->header('Cache-Control'), $no_cache,
+        'Cache-Control for no-cache';
+    is $res->header('Pragma'),  'no-cache',
+        'Pragma: no-cache';
+    is $res->header('Expires'), '0',
+        'Expires: 0';
+};
 
-{
-    note('Testing XXX_never_cache headers');
+subtest 'Some caching headers' => sub {
+    my $res = request('/some_caching');
+    like $res->content, qr/Browser and CDN cacheing different max ages/;
 
-    $mech->get('/page_with_no_caching');
-    $mech->content_contains("No caching here");
-
-    $mech->lacks_header_ok( 'Surrogate-Control',
-        'Surrogate-Control not there as expected' );
-    $mech->header_is( 'Cache-Control', $no_cache,
-        'Cache-Control for no-cache' );
-    $mech->header_is( 'Pragma',  'no-cache', 'Pragma: no-cache' );
-    $mech->header_is( 'Expires', '0',        'Expires: 0' );
-}
-
-{
-    note('Some caching headers');
-
-    $mech->get('/some_caching');
-    $mech->content_contains("Browser and CDN cacheing different max ages");
-
-    $mech->header_is(
-        'Surrogate-Control',
+    is $res->header('Surrogate-Control'),
         'max-age=600, stale-while-revalidate=86400, stale-if-error=172800',
-        'Surrogate-Control: set to max-age=600, stale-while-revalidate=86400, stale-if-error=172800'
-    );
-    $mech->header_is(
-        'Cache-Control',
+        'Surrogate-Control: set to max-age=600, stale-while-revalidate=86400, stale-if-error=172800';
+    is $res->header('Cache-Control'),
         'max-age=10, stale-while-revalidate=172800, stale-if-error=259200',
-        'Cache-Control for browser set to max-age=10, stale-while-revalidate=172800, stale-if-error=259200'
-    );
-    $mech->lacks_header_ok( 'Pragma',  'No Pragma header' );
-    $mech->lacks_header_ok( 'Expires', 'No Expires header' );
+        'Cache-Control for browser set to max-age=10, stale-while-revalidate=172800, stale-if-error=259200';
+    is $res->header('Pragma'), undef,
+        'No Pragma header';
+    is $res->header('Expires'), undef,
+        'No Expires header';
 
-}
+};
 
-{
-    note('Browser caching, but not CDN');
+subtest 'Browser caching, but not CDN' => sub {
+    my $res = request('/cdn_no_cache_browser_cache');
+    like $res->content, qr/Browser cacheing, CDN no cache/;
 
-    $mech->get('/cdn_no_cache_browser_cache');
-    $mech->content_contains("Browser cacheing, CDN no cache");
+    is $res->header('Cache-Control'), 'max-age=10, private',
+        'Cache-Control, with private for CDN set to max-age=10, private';
+    is $res->header('Surrogate-Control'), undef,
+        'No Surrogate-Control header';
+    is $res->header('Pragma'), undef,
+        'No Pragma header';
+    is $res->header('Expires'), undef,
+        'No Expires header';
+};
 
-    $mech->header_is(
-        'Cache-Control',
-        'max-age=10, private',
-        'Cache-Control, with private for CDN set to max-age=10, private'
-    );
-    $mech->lacks_header_ok( 'Surrogate-Control',
-        'No Surrogate-Control header' );
-    $mech->lacks_header_ok( 'Pragma',  'No Pragma header' );
-    $mech->lacks_header_ok( 'Expires', 'No Expires header' );
+subtest 'Browser caching NOT set, and not CDN' => sub {
+    my $res = request('/cdn_no_browser_cache_not_set');
+    like $res->content, qr/Browser cacheing not set, CDN no cache/;
 
-}
+    is $res->header('Cache-Control'), 'private',
+        'Cache-Control, with private for CDN';
+    is $res->header('Surrogate-Control'), undef,
+        'No Surrogate-Control header';
+    is $res->header('Pragma'), undef,
+        'No Pragma header';
+    is $res->header('Expires'), undef,
+        'No Expires header';
+};
 
-{
-    note('Browser caching NOT set, and not CDN');
+subtest 'Surrogate keys - basic' => sub {
+    my $res = request('/some_surrogate_keys');
+    like $res->content, qr/surrogate keys/;
 
-    $mech->get('/cdn_no_browser_cache_not_set');
-    $mech->content_contains("Browser cacheing not set, CDN no cache");
+    is $res->header('Surrogate-Key'), 'f%oo W1-BBL3!',
+        'Surrogate-Keys: set to "f%oo W1BBL3"';
 
-    $mech->header_is( 'Cache-Control', 'private',
-        'Cache-Control, with private for CDN' );
-    $mech->lacks_header_ok( 'Surrogate-Control',
-        'No Surrogate-Control header' );
-    $mech->lacks_header_ok( 'Pragma',  'No Pragma header' );
-    $mech->lacks_header_ok( 'Expires', 'No Expires header' );
-
-}
-
-{
-    note('Surrogate keys - basic');
-
-    $mech->get('/some_surrogate_keys');
-    $mech->content_contains("surrogate keys");
-
-    $mech->header_is(
-        'Surrogate-Key',
-        'f%oo W1-BBL3!',
-        'Surrogate-Keys: set to "f%oo W1BBL3"'
-    );
-
-    $mech->lacks_header_ok( 'Surrogate-Control',
-        'No Surrogate-Control header' );
-    $mech->lacks_header_ok( 'Cache-Control', 'No ache-Control header' );
-
-    $mech->lacks_header_ok( 'Pragma',  'No Pragma header' );
-    $mech->lacks_header_ok( 'Expires', 'No Expires header' );
-
-}
+    is $res->header('Surrogate-Control'), undef,
+        'No Surrogate-Control header';
+    is $res->header('Cache-Control'), undef,
+        'No ache-Control header';
+    is $res->header('Pragma'), undef,
+        'No Pragma header';
+    is $res->header('Expires'), undef,
+        'No Expires header';
+};
 
 done_testing();
-

--- a/t/lib/Test/App.pm
+++ b/t/lib/Test/App.pm
@@ -6,7 +6,6 @@ use Test::More;
 use Catalyst::Runtime 5.80;
 
 use Catalyst qw/
-    -Debug
     +CatalystX::Fastly::Role::Response
 
     /;


### PR DESCRIPTION
We don't need any of the things WWW::Mechanize provides like form filling or session tracking. Catalyst::Test can do everything we need without making the tests more complicated, and it is included with Catalyst rather than needing an additional prereq.